### PR TITLE
updated search_google_places_widget.dart

### DIFF
--- a/lib/src/search_google_places_widget.dart
+++ b/lib/src/search_google_places_widget.dart
@@ -96,6 +96,10 @@ class _SearchMapPlaceWidgetState extends State<SearchGooglePlacesWidget>
   FocusNode _fn = FocusNode();
 
   CrossFadeState? _crossFadeState;
+  
+  void setStateIfMounted(f) {
+    if (mounted) setState(f);
+  }
 
   @override
   void initState() {
@@ -124,9 +128,9 @@ class _SearchMapPlaceWidgetState extends State<SearchGooglePlacesWidget>
     if (widget.hasClearButton!) {
       _fn.addListener(() async {
         if (_fn.hasFocus)
-          setState(() => _crossFadeState = CrossFadeState.showSecond);
+          setStateIfMounted(() => _crossFadeState = CrossFadeState.showSecond);
         else
-          setState(() => _crossFadeState = CrossFadeState.showFirst);
+          setStateIfMounted(() => _crossFadeState = CrossFadeState.showFirst);
       });
       _crossFadeState = CrossFadeState.showFirst;
     }
@@ -272,7 +276,7 @@ class _SearchMapPlaceWidgetState extends State<SearchGooglePlacesWidget>
   /// Api and giving the user Place options
   void _autocompletePlace() async {
     if (_fn.hasFocus) {
-      setState(() {
+      setStateIfMounted(() {
         _currentInput = _textEditingController.text;
         _isEditing = true;
       });
@@ -288,7 +292,7 @@ class _SearchMapPlaceWidgetState extends State<SearchGooglePlacesWidget>
       if (_currentInput == _tempInput) {
         final predictions = await _makeRequest(_currentInput);
         await _animationController!.animateTo(0.5);
-        setState(() => _placePredictions = predictions);
+        setStateIfMounted(() => _placePredictions = predictions);
         await _animationController!.forward();
 
         _textEditingController.addListener(_autocompletePlace);
@@ -357,7 +361,7 @@ class _SearchMapPlaceWidgetState extends State<SearchGooglePlacesWidget>
     if (!_animationController!.isDismissed)
       await _animationController!.animateTo(0.5);
     _fn.unfocus();
-    setState(() {
+    setStateIfMounted(() {
       _placePredictions = [];
       _isEditing = false;
     });
@@ -368,7 +372,7 @@ class _SearchMapPlaceWidgetState extends State<SearchGooglePlacesWidget>
   /// Will listen for input changes every 0.5 seconds, allowing us to make API requests only when the user stops typing.
   void customListener() {
     Future.delayed(Duration(milliseconds: 500), () {
-      setState(() => _tempInput = _textEditingController.text);
+      setStateIfMounted(() => _tempInput = _textEditingController.text);
       customListener();
     });
   }


### PR DESCRIPTION
Updated search_google_places_widget.dart by adding `setStateIfMounted()` to avoid triggering the following error: `setState() called after dispose()`
This happens when SearchGooglePlacesWidget is not in the first screen of an app and can be popped. When popping, the error `setState() called after dispose()` is triggered. Adding `setStateIfMounted` resolves the issue.